### PR TITLE
Add tests that exercise OKE driver CRUD (VCN, clusters, nodepools)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ binary-build:
 #
 .PHONY: unit-test
 unit-test: go-install
-	go test -v ./oke
+	GO111MODULE=on go test -v ./oke
 
 .PHONY: integ-test
 integ-test: go-install

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/kontainer-engine v0.0.4-dev.0.20210625182816-1a4f4e73a324
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/net v0.41.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.27.8
@@ -43,6 +44,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rancher/rke v1.5.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sony/gobreaker v0.5.0 // indirect

--- a/oke/fakes/fake_ce_client.go
+++ b/oke/fakes/fake_ce_client.go
@@ -1,0 +1,275 @@
+// Copyright 2019 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakes
+
+import (
+	"bytes"
+	"context"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/containerengine"
+	"io/ioutil"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"time"
+)
+
+type ContainerEngineClient struct {
+	//ContainerEngineClientInterface
+
+	clusters  map[string]containerengine.Cluster
+	nodepools map[string]containerengine.NodePool
+
+	workRequests map[string]containerengine.WorkRequest
+}
+
+// NewContainerEngineClient returns a client that will respond with the provided objects.
+// It shouldn't be used as a replacement for a real client and is mostly useful in simple unit tests.
+// func NewContainerEngineClient() (client ContainerEngineClient, err error) {
+func NewContainerEngineClient() (client ContainerEngineClient, err error) {
+	c := ContainerEngineClient{}
+	c.clusters = make(map[string]containerengine.Cluster)
+	c.nodepools = make(map[string]containerengine.NodePool)
+	c.workRequests = make(map[string]containerengine.WorkRequest)
+	return c, nil
+}
+
+func (client ContainerEngineClient) CreateCluster(ctx context.Context, request containerengine.CreateClusterRequest) (response containerengine.CreateClusterResponse, err error) {
+	cl := containerengine.Cluster{}
+	ocid := string(uuid.NewUUID())
+	cl.Id = &ocid
+	cl.Name = request.Name
+	cl.VcnId = request.VcnId
+	cl.KubernetesVersion = request.KubernetesVersion
+	cl.CompartmentId = request.CompartmentId
+	cl.Options = request.Options
+	client.clusters[ocid] = cl
+
+	wr := containerengine.WorkRequest{}
+	wr.Id = &ocid
+	client.workRequests[ocid] = wr
+
+	response = containerengine.CreateClusterResponse{}
+	response.OpcWorkRequestId = wr.Id
+
+	return response, nil
+}
+
+func (client ContainerEngineClient) CreateKubeconfig(ctx context.Context, request containerengine.CreateKubeconfigRequest) (response containerengine.CreateKubeconfigResponse, err error) {
+
+	kubeconfig := `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: http://127.1.2.3:6443
+  name: ` + *request.ClusterId + `
+contexts:
+- context:
+    cluster: integration
+    user: test
+  name: default-context
+current-context: default-context
+users:
+- name: test
+  user:
+    password: test
+    username: test
+`
+	response = containerengine.CreateKubeconfigResponse{Content: ioutil.NopCloser(bytes.NewReader([]byte(kubeconfig)))}
+	return response, nil
+}
+
+func (client ContainerEngineClient) CreateNodePool(ctx context.Context, request containerengine.CreateNodePoolRequest) (response containerengine.CreateNodePoolResponse, err error) {
+	np := containerengine.NodePool{}
+	ocid := string(uuid.NewUUID())
+	np.Id = &ocid
+	np.ClusterId = request.ClusterId
+	np.Name = request.Name
+	np.CompartmentId = request.CompartmentId
+	np.KubernetesVersion = request.KubernetesVersion
+	np.SubnetIds = request.SubnetIds
+	np.QuantityPerSubnet = request.QuantityPerSubnet
+	if request.NodeConfigDetails != nil && request.NodeConfigDetails.Size != nil {
+		np.QuantityPerSubnet = request.NodeConfigDetails.Size
+	}
+	np.InitialNodeLabels = request.InitialNodeLabels
+	client.nodepools[ocid] = np
+
+	wr := containerengine.WorkRequest{}
+	wr.Id = &ocid
+	client.workRequests[ocid] = wr
+
+	response = containerengine.CreateNodePoolResponse{}
+	response.OpcWorkRequestId = wr.Id
+
+	return response, nil
+}
+
+func (client ContainerEngineClient) DeleteCluster(ctx context.Context, request containerengine.DeleteClusterRequest) (response containerengine.DeleteClusterResponse, err error) {
+	delete(client.clusters, *request.ClusterId)
+	wr := containerengine.WorkRequest{}
+	wr.Id = request.ClusterId
+
+	response = containerengine.DeleteClusterResponse{}
+	response.OpcWorkRequestId = wr.Id
+
+	return response, nil
+}
+
+func (client ContainerEngineClient) DeleteNodePool(ctx context.Context, request containerengine.DeleteNodePoolRequest) (response containerengine.DeleteNodePoolResponse, err error) {
+
+	delete(client.nodepools, *request.NodePoolId)
+	wr := containerengine.WorkRequest{}
+	wr.Id = request.NodePoolId
+
+	response = containerengine.DeleteNodePoolResponse{}
+	response.OpcWorkRequestId = wr.Id
+
+	return response, nil
+}
+
+func (client ContainerEngineClient) GetCluster(ctx context.Context, request containerengine.GetClusterRequest) (response containerengine.GetClusterResponse, err error) {
+	response = containerengine.GetClusterResponse{}
+	if cluster, ok := client.clusters[*request.ClusterId]; ok {
+		response.Cluster = cluster
+		return response, nil
+	}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+func (client ContainerEngineClient) GetClusterOptions(ctx context.Context, request containerengine.GetClusterOptionsRequest) (response containerengine.GetClusterOptionsResponse, err error) {
+	response = containerengine.GetClusterOptionsResponse{}
+	response.KubernetesVersions = []string{"v1.12.7", "v1.13.5"}
+	return response, nil
+}
+
+func (client ContainerEngineClient) GetNodePoolOptions(ctx context.Context, request containerengine.GetNodePoolOptionsRequest) (response containerengine.GetNodePoolOptionsResponse, err error) {
+	sourceName := "Oracle-Linux-7.7"
+	imageID := string(uuid.NewUUID())
+	response = containerengine.GetNodePoolOptionsResponse{}
+	response.Sources = []containerengine.NodeSourceOption{
+		containerengine.NodeSourceViaImageOption{
+			SourceName: &sourceName,
+			ImageId:    &imageID,
+		},
+	}
+	return response, nil
+}
+
+func (client ContainerEngineClient) GetNodePool(ctx context.Context, request containerengine.GetNodePoolRequest) (response containerengine.GetNodePoolResponse, err error) {
+	response = containerengine.GetNodePoolResponse{}
+	if np, ok := client.nodepools[*request.NodePoolId]; ok {
+		response.NodePool = np
+		return response, nil
+	}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+func (client ContainerEngineClient) GetWorkRequest(ctx context.Context, request containerengine.GetWorkRequestRequest) (response containerengine.GetWorkRequestResponse, err error) {
+
+	clusterEt := string(containerengine.ListWorkRequestsResourceTypeCluster)
+
+	response = containerengine.GetWorkRequestResponse{}
+	if wr, ok := client.workRequests[*request.WorkRequestId]; ok {
+		response.Id = wr.Id
+		response.TimeFinished = &common.SDKTime{time.Now()}
+		response.Resources = []containerengine.WorkRequestResource{{
+			ActionType: containerengine.WorkRequestResourceActionTypeCreated,
+			EntityType: &clusterEt,
+			Identifier: client.clusters[*request.WorkRequestId].Id,
+			EntityUri:  nil,
+		}}
+		return response, nil
+	}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+func (client ContainerEngineClient) ListClusters(ctx context.Context, request containerengine.ListClustersRequest) (response containerengine.ListClustersResponse, err error) {
+	response = containerengine.ListClustersResponse{}
+	response.Items = []containerengine.ClusterSummary{}
+	for _, value := range client.clusters {
+		nps := containerengine.ClusterSummary{
+			Id:                value.Id,
+			CompartmentId:     value.CompartmentId,
+			Name:              value.Name,
+			KubernetesVersion: value.KubernetesVersion,
+		}
+		response.Items = append(response.Items, nps)
+	}
+
+	return response, nil
+}
+
+func (client ContainerEngineClient) ListNodePools(ctx context.Context, request containerengine.ListNodePoolsRequest) (response containerengine.ListNodePoolsResponse, err error) {
+	response = containerengine.ListNodePoolsResponse{}
+	response.Items = []containerengine.NodePoolSummary{}
+	for _, value := range client.nodepools {
+		nps := containerengine.NodePoolSummary{
+			Id:                value.Id,
+			CompartmentId:     value.CompartmentId,
+			ClusterId:         value.ClusterId,
+			Name:              value.Name,
+			KubernetesVersion: value.KubernetesVersion,
+			NodeImageId:       value.NodeImageId,
+			NodeImageName:     value.NodeImageName,
+			NodeShape:         value.NodeShape,
+		}
+		response.Items = append(response.Items, nps)
+	}
+
+	return response, nil
+}
+
+func (client ContainerEngineClient) UpdateCluster(ctx context.Context, request containerengine.UpdateClusterRequest) (response containerengine.UpdateClusterResponse, err error) {
+	response = containerengine.UpdateClusterResponse{}
+	if cl, ok := client.clusters[*request.ClusterId]; ok {
+		cl.KubernetesVersion = request.KubernetesVersion
+		if request.KubernetesVersion != nil && *request.KubernetesVersion != "" {
+			cl.KubernetesVersion = request.KubernetesVersion
+		}
+		client.clusters[*request.ClusterId] = cl
+		wr := containerengine.WorkRequest{}
+		wr.Id = cl.Id
+		client.workRequests[*cl.Id] = wr
+		response.OpcWorkRequestId = wr.Id
+		return response, nil
+	}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+func (client ContainerEngineClient) UpdateClusterEndpointConfig(ctx context.Context, request containerengine.UpdateClusterEndpointConfigRequest) (response containerengine.UpdateClusterEndpointConfigResponse, err error) {
+	return containerengine.UpdateClusterEndpointConfigResponse{}, nil
+}
+
+func (client ContainerEngineClient) UpdateNodePool(ctx context.Context, request containerengine.UpdateNodePoolRequest) (response containerengine.UpdateNodePoolResponse, err error) {
+	response = containerengine.UpdateNodePoolResponse{}
+	if np, ok := client.nodepools[*request.NodePoolId]; ok {
+		if request.KubernetesVersion != nil && *request.KubernetesVersion != "" {
+			np.KubernetesVersion = request.KubernetesVersion
+		}
+		if request.QuantityPerSubnet != nil {
+			np.QuantityPerSubnet = request.QuantityPerSubnet
+		}
+		if request.NodeConfigDetails != nil && request.NodeConfigDetails.Size != nil {
+			np.QuantityPerSubnet = request.NodeConfigDetails.Size
+		}
+		client.nodepools[*request.NodePoolId] = np
+		wr := containerengine.WorkRequest{}
+		wr.Id = np.Id
+		client.workRequests[*np.Id] = wr
+		response.OpcWorkRequestId = wr.Id
+		return response, nil
+	}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}

--- a/oke/fakes/fake_compute_client.go
+++ b/oke/fakes/fake_compute_client.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakes
+
+import (
+	"context"
+
+	ocicore "github.com/oracle/oci-go-sdk/v65/core"
+)
+
+type ComputeClient struct{}
+
+func NewComputeClient() (client *ComputeClient, err error) {
+	return &ComputeClient{}, nil
+}
+
+func (client *ComputeClient) ListShapes(ctx context.Context, request ocicore.ListShapesRequest) (response ocicore.ListShapesResponse, err error) {
+	shapeName := "VM.Standard2.1"
+	response = ocicore.ListShapesResponse{}
+	if request.AvailabilityDomain != nil && *request.AvailabilityDomain != "AD-1" {
+		return response, nil
+	}
+	response.Items = []ocicore.Shape{{
+		Shape: &shapeName,
+	}}
+	return response, nil
+}

--- a/oke/fakes/fake_errors.go
+++ b/oke/fakes/fake_errors.go
@@ -1,0 +1,43 @@
+// Copyright 2019 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakes
+
+import (
+	"fmt"
+)
+
+type servicefailure struct {
+	StatusCode int
+	Code       string `json:"code,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+func (se servicefailure) Error() string {
+	return fmt.Sprintf("Service error:%s. %s. http status code: %d",
+		se.Code, se.Message, se.StatusCode)
+}
+
+func (se servicefailure) GetHTTPStatusCode() int {
+	return se.StatusCode
+
+}
+
+func (se servicefailure) GetMessage() string {
+	return se.Message
+}
+
+func (se servicefailure) GetCode() string {
+	return se.Code
+}

--- a/oke/fakes/fake_identity_client.go
+++ b/oke/fakes/fake_identity_client.go
@@ -1,0 +1,147 @@
+// Copyright 2019 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakes
+
+import (
+	"context"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	ociid "github.com/oracle/oci-go-sdk/v65/identity"
+)
+
+// IdentityClient implements common IdentityClient to fake oci methods for unit tests.
+type IdentityClient struct {
+	//IdentityClientInterface
+
+	policies     map[string]ociid.Policy
+	compartments map[string]ociid.Compartment
+}
+
+// NewIdentityClient returns a client that will respond with the provided objects.
+// It shouldn't be used as a replacement for a real client and is mostly useful in simple unit tests.
+func NewIdentityClient() (fcc *IdentityClient, err error) {
+	c := IdentityClient{}
+
+	c.policies = make(map[string]ociid.Policy)
+	c.compartments = make(map[string]ociid.Compartment)
+	return &c, nil
+}
+
+// CreateCompartment creates and returns a fake response
+func (cc *IdentityClient) CreateCompartment(ctx context.Context, request ociid.CreateCompartmentRequest) (response ociid.CreateCompartmentResponse, err error) {
+
+	response = ociid.CreateCompartmentResponse{}
+	compartment := ociid.Compartment{}
+	ocid := string(uuid.NewUUID())
+	compartment.Id = &ocid
+	cc.compartments[ocid] = compartment
+
+	response.Id = &ocid
+	return response, nil
+}
+
+// GetCompartment returns a fake response for GetCompartment
+func (cc *IdentityClient) GetCompartment(ctx context.Context, request ociid.GetCompartmentRequest) (response ociid.GetCompartmentResponse, err error) {
+	response = ociid.GetCompartmentResponse{}
+	if compartment, ok := cc.compartments[*request.CompartmentId]; ok {
+		response.Compartment = compartment
+		return response, nil
+	}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+func (cc *IdentityClient) DeleteCompartment(ctx context.Context, request ociid.DeleteCompartmentRequest) (response ociid.DeleteCompartmentResponse, err error) {
+	id := *request.CompartmentId
+	delete(cc.compartments, id)
+	response = ociid.DeleteCompartmentResponse{}
+	return response, nil
+}
+
+// ListCompartments returns a fake response for ListCompartments
+func (cc *IdentityClient) ListCompartments(ctx context.Context, request ociid.ListCompartmentsRequest) (response ociid.ListCompartmentsResponse, err error) {
+	response = ociid.ListCompartmentsResponse{}
+	response.Items = []ociid.Compartment{}
+	for _, value := range cc.compartments {
+		response.Items = append(response.Items, value)
+	}
+
+	return response, nil
+}
+
+// ListAvailabilityDomains returns a fake response (AD-1, AD-2, AD-3) for ListAvailabilityDomains
+func (cc *IdentityClient) ListAvailabilityDomains(ctx context.Context, request ociid.ListAvailabilityDomainsRequest) (response ociid.ListAvailabilityDomainsResponse, err error) {
+	response = ociid.ListAvailabilityDomainsResponse{}
+
+	for i := 1; i <= 3; i++ {
+		testName := "AD-" + strconv.Itoa(i)
+		rootCompartment := "compartment.root.test1"
+		item := ociid.AvailabilityDomain{
+			Name:          &testName,
+			CompartmentId: &rootCompartment,
+		}
+		response.Items = append(response.Items, item)
+	}
+
+	return response, nil
+}
+
+func (cc *IdentityClient) ListFaultDomains(ctx context.Context, request ociid.ListFaultDomainsRequest) (response ociid.ListFaultDomainsResponse, err error) {
+	response = ociid.ListFaultDomainsResponse{}
+	testName := "FAULT-DOMAIN-1"
+	response.Items = append(response.Items, ociid.FaultDomain{
+		AvailabilityDomain: request.AvailabilityDomain,
+		Name:               &testName,
+	})
+	return response, nil
+}
+
+// CreatePolicy returns a fake response for CreatePolicy
+func (cc *IdentityClient) CreatePolicy(ctx context.Context, request ociid.CreatePolicyRequest) (response ociid.CreatePolicyResponse, err error) {
+
+	response = ociid.CreatePolicyResponse{}
+	policy := ociid.Policy{}
+	ocid := string(uuid.NewUUID())
+	policy.Id = &ocid
+	cc.policies[ocid] = policy
+
+	response.Id = &ocid
+	return response, nil
+}
+
+// DeletePolicy returns a fake response for DeletePolicy
+func (cc *IdentityClient) DeletePolicy(ctx context.Context, request ociid.DeletePolicyRequest) (response ociid.DeletePolicyResponse, err error) {
+	id := *request.PolicyId
+	delete(cc.policies, id)
+	response = ociid.DeletePolicyResponse{}
+	return response, nil
+}
+
+// GetPolicy returns a fake response for GetPolicy
+func (cc *IdentityClient) GetPolicy(ctx context.Context, request ociid.GetPolicyRequest) (response ociid.GetPolicyResponse, err error) {
+	response = ociid.GetPolicyResponse{}
+	if policy, ok := cc.policies[*request.PolicyId]; ok {
+		response.Policy = policy
+		return response, nil
+	}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+// UpdatePolicy returns a fake response for UpdatePolicy
+func (cc *IdentityClient) UpdatePolicy(ctx context.Context, request ociid.UpdatePolicyRequest) (response ociid.UpdatePolicyResponse, err error) {
+	response = ociid.UpdatePolicyResponse{}
+	return response, nil
+}

--- a/oke/fakes/fake_vcn_client.go
+++ b/oke/fakes/fake_vcn_client.go
@@ -1,0 +1,471 @@
+// Copyright 2019 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakes
+
+import (
+	"context"
+	ocicore "github.com/oracle/oci-go-sdk/v65/core"
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+// VcnClient implements common VcnClientInterface to fake oci methods for unit tests.
+type VcnClient struct {
+	//VcnClientInterface
+
+	dhcpOptions      map[string]ocicore.DhcpOptions
+	internetGateways map[string]ocicore.InternetGateway
+	natGateways      map[string]ocicore.NatGateway
+	routeTables      map[string]ocicore.RouteTable
+	securityLists    map[string]ocicore.SecurityList
+	serviceGateways  map[string]ocicore.ServiceGateway
+	subnets          map[string]ocicore.Subnet
+	vcns             map[string]ocicore.Vcn
+}
+
+func WTF() {
+
+}
+
+// NewVcnClient returns a client that will respond with the provided objects.
+// It shouldn't be used as a replacement for a real client and is mostly useful in simple unit tests.
+func NewVcnClient() (fvcnc *VcnClient, err error) {
+	c := VcnClient{}
+
+	c.dhcpOptions = make(map[string]ocicore.DhcpOptions)
+	c.internetGateways = make(map[string]ocicore.InternetGateway)
+	c.natGateways = make(map[string]ocicore.NatGateway)
+	c.routeTables = make(map[string]ocicore.RouteTable)
+	c.securityLists = make(map[string]ocicore.SecurityList)
+	c.serviceGateways = make(map[string]ocicore.ServiceGateway)
+	c.subnets = make(map[string]ocicore.Subnet)
+	c.vcns = make(map[string]ocicore.Vcn)
+
+	// Default Route Table
+	rt := ocicore.RouteTable{}
+	ocid := string(uuid.NewUUID())
+	rt.Id = &ocid
+	c.routeTables[ocid] = rt
+
+	return &c, nil
+}
+
+// CreateDhcpOptions returns a fake response for CreateDhcpOptions
+func (vcnc *VcnClient) CreateDhcpOptions(ctx context.Context, request ocicore.CreateDhcpOptionsRequest) (response ocicore.CreateDhcpOptionsResponse, err error) {
+
+	response = ocicore.CreateDhcpOptionsResponse{}
+	vcn := ocicore.Vcn{}
+	ocid := string(uuid.NewUUID())
+	vcn.Id = &ocid
+	vcnc.vcns[ocid] = vcn
+
+	response.Id = &ocid
+	return response, nil
+}
+
+// DeleteDhcpOptions returns a fake response for DeleteDhcpOptions
+func (vcnc *VcnClient) DeleteDhcpOptions(ctx context.Context, request ocicore.DeleteDhcpOptionsRequest) (response ocicore.DeleteDhcpOptionsResponse, err error) {
+	id := *request.DhcpId
+	delete(vcnc.dhcpOptions, id)
+	response = ocicore.DeleteDhcpOptionsResponse{}
+	return response, nil
+
+}
+
+// GetDhcpOptions returns a fake response for CreateDhcpOptions
+func (vcnc *VcnClient) GetDhcpOptions(ctx context.Context, request ocicore.GetDhcpOptionsRequest) (response ocicore.GetDhcpOptionsResponse, err error) {
+	response = ocicore.GetDhcpOptionsResponse{}
+	return response, nil
+}
+
+// UpdateDhcpOptions returns a fake response for UpdateDhcpOptions
+func (vcnc *VcnClient) UpdateDhcpOptions(ctx context.Context, request ocicore.UpdateDhcpOptionsRequest) (response ocicore.UpdateDhcpOptionsResponse, err error) {
+	response = ocicore.UpdateDhcpOptionsResponse{}
+	return response, nil
+}
+
+// CreateInternetGateway returns a fake response for CreateInternetGateway
+func (vcnc *VcnClient) CreateInternetGateway(ctx context.Context, request ocicore.CreateInternetGatewayRequest) (response ocicore.CreateInternetGatewayResponse, err error) {
+	response = ocicore.CreateInternetGatewayResponse{}
+
+	ig := ocicore.InternetGateway{}
+	ocid := string(uuid.NewUUID())
+	ig.Id = &ocid
+	ig.CompartmentId = request.CompartmentId
+	ig.IsEnabled = request.IsEnabled
+	ig.VcnId = ig.VcnId
+	ig.DisplayName = ig.DisplayName
+	vcnc.internetGateways[ocid] = ig
+
+	response.InternetGateway = ig
+	return response, nil
+}
+
+// CreateNatGateway returns a fake response for CreateNatGateway
+func (vcnc *VcnClient) CreateNatGateway(ctx context.Context, request ocicore.CreateNatGatewayRequest) (response ocicore.CreateNatGatewayResponse, err error) {
+	response = ocicore.CreateNatGatewayResponse{}
+
+	ig := ocicore.NatGateway{}
+	ocid := string(uuid.NewUUID())
+	ig.Id = &ocid
+	ig.CompartmentId = request.CompartmentId
+	ig.VcnId = ig.VcnId
+	ig.DisplayName = ig.DisplayName
+	vcnc.natGateways[ocid] = ig
+
+	response.NatGateway = ig
+	return response, nil
+}
+
+func (vcnc *VcnClient) DeleteNatGateway(ctx context.Context, request ocicore.DeleteNatGatewayRequest) (response ocicore.DeleteNatGatewayResponse, err error) {
+	// TODO
+	return ocicore.DeleteNatGatewayResponse{}, nil
+}
+
+func (vcnc *VcnClient) CreateServiceGateway(ctx context.Context, request ocicore.CreateServiceGatewayRequest) (response ocicore.CreateServiceGatewayResponse, err error) {
+	response = ocicore.CreateServiceGatewayResponse{}
+	sg := ocicore.ServiceGateway{}
+	ocid := string(uuid.NewUUID())
+	sg.Id = &ocid
+	sg.CompartmentId = request.CompartmentId
+	sg.VcnId = request.VcnId
+	sg.DisplayName = request.DisplayName
+	vcnc.serviceGateways[ocid] = sg
+	response.ServiceGateway = sg
+	return response, nil
+}
+
+func (vcnc *VcnClient) DeleteServiceGateway(ctx context.Context, request ocicore.DeleteServiceGatewayRequest) (response ocicore.DeleteServiceGatewayResponse, err error) {
+	delete(vcnc.serviceGateways, *request.ServiceGatewayId)
+	return ocicore.DeleteServiceGatewayResponse{}, nil
+}
+
+// UpdateInternetGateway returns a fake response for UpdateInternetGateway
+func (vcnc *VcnClient) UpdateInternetGateway(ctx context.Context, request ocicore.UpdateInternetGatewayRequest) (response ocicore.UpdateInternetGatewayResponse, err error) {
+	response = ocicore.UpdateInternetGatewayResponse{}
+
+	if ig, ok := vcnc.internetGateways[*request.IgId]; ok {
+		response.InternetGateway = ig
+		return response, nil
+	}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+// DeleteInternetGateway returns a fake response for DeleteInternetGateway
+func (vcnc *VcnClient) DeleteInternetGateway(ctx context.Context, request ocicore.DeleteInternetGatewayRequest) (response ocicore.DeleteInternetGatewayResponse, err error) {
+	id := *request.IgId
+	delete(vcnc.internetGateways, id)
+	response = ocicore.DeleteInternetGatewayResponse{}
+	return response, nil
+}
+
+// GetInternetGateway returns a fake response for GetInternetGateway
+func (vcnc *VcnClient) GetInternetGateway(ctx context.Context, request ocicore.GetInternetGatewayRequest) (response ocicore.GetInternetGatewayResponse, err error) {
+	response = ocicore.GetInternetGatewayResponse{}
+
+	if ig, ok := vcnc.internetGateways[*request.IgId]; ok {
+		response.InternetGateway = ig
+		return response, nil
+	}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+// CreateSubnet returns a fake response for CreateSubnet
+func (vcnc *VcnClient) CreateSubnet(ctx context.Context, request ocicore.CreateSubnetRequest) (response ocicore.CreateSubnetResponse, err error) {
+
+	subnet := ocicore.Subnet{}
+	ocid := string(uuid.NewUUID())
+	subnet.Id = &ocid
+	subnet.CidrBlock = request.CidrBlock
+	subnet.CompartmentId = request.CompartmentId
+	subnet.VcnId = request.VcnId
+	subnet.AvailabilityDomain = request.AvailabilityDomain
+	subnet.DisplayName = request.DisplayName
+	subnet.DnsLabel = request.DnsLabel
+	subnet.ProhibitPublicIpOnVnic = request.ProhibitPublicIpOnVnic
+	subnet.SecurityListIds = request.SecurityListIds
+	subnet.RouteTableId = request.RouteTableId
+	vcnc.subnets[ocid] = subnet
+
+	response = ocicore.CreateSubnetResponse{}
+	response.Subnet = subnet
+	return response, nil
+}
+
+// DeleteSubnet returns a fake response for DeleteSubnet
+func (vcnc *VcnClient) DeleteSubnet(ctx context.Context, request ocicore.DeleteSubnetRequest) (response ocicore.DeleteSubnetResponse, err error) {
+
+	id := *request.SubnetId
+	delete(vcnc.subnets, id)
+	response = ocicore.DeleteSubnetResponse{}
+	return response, nil
+}
+
+// UpdateSubnet returns a fake response for UpdateSubnet
+func (vcnc *VcnClient) UpdateSubnet(ctx context.Context, request ocicore.UpdateSubnetRequest) (response ocicore.UpdateSubnetResponse, err error) {
+
+	if subnet, ok := vcnc.subnets[*request.SubnetId]; ok {
+		response = ocicore.UpdateSubnetResponse{}
+		response.Subnet = subnet
+		return response, nil
+	}
+	response = ocicore.UpdateSubnetResponse{}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+// GetSubnet returns a fake response for GetSubnet
+func (vcnc *VcnClient) GetSubnet(ctx context.Context, request ocicore.GetSubnetRequest) (response ocicore.GetSubnetResponse, err error) {
+	response = ocicore.GetSubnetResponse{}
+
+	if subnet, ok := vcnc.subnets[*request.SubnetId]; ok {
+		response.Subnet = subnet
+		return response, nil
+	}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+// CreateSecurityList returns a fake response for CreateSecurityList
+func (vcnc *VcnClient) CreateSecurityList(ctx context.Context, request ocicore.CreateSecurityListRequest) (response ocicore.CreateSecurityListResponse, err error) {
+
+	sl := ocicore.SecurityList{}
+	ocid := string(uuid.NewUUID())
+	sl.Id = &ocid
+	sl.CompartmentId = request.CompartmentId
+	sl.EgressSecurityRules = request.EgressSecurityRules
+	sl.IngressSecurityRules = request.IngressSecurityRules
+	sl.VcnId = sl.VcnId
+	sl.DisplayName = sl.DisplayName
+	vcnc.securityLists[ocid] = sl
+
+	response = ocicore.CreateSecurityListResponse{}
+	response.SecurityList = sl
+	return response, nil
+}
+
+// UpdateSecurityList returns a fake response for UpdateSecurityList
+func (vcnc *VcnClient) UpdateSecurityList(ctx context.Context, request ocicore.UpdateSecurityListRequest) (response ocicore.UpdateSecurityListResponse, err error) {
+
+	if sl, ok := vcnc.securityLists[*request.SecurityListId]; ok {
+		response = ocicore.UpdateSecurityListResponse{}
+		response.SecurityList = sl
+		return response, nil
+	}
+	response = ocicore.UpdateSecurityListResponse{}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+// DeleteSecurityList returns a fake response for DeleteSecurityList
+func (vcnc *VcnClient) DeleteSecurityList(ctx context.Context, request ocicore.DeleteSecurityListRequest) (response ocicore.DeleteSecurityListResponse, err error) {
+	id := *request.SecurityListId
+	delete(vcnc.securityLists, id)
+	response = ocicore.DeleteSecurityListResponse{}
+	return response, nil
+}
+
+// GetSecurityList returns a fake response for GetSecurityList
+func (vcnc *VcnClient) GetSecurityList(ctx context.Context, request ocicore.GetSecurityListRequest) (response ocicore.GetSecurityListResponse, err error) {
+	return ocicore.GetSecurityListResponse{}, nil
+}
+
+// CreateRouteTable returns a fake response for CreateRouteTable
+func (vcnc *VcnClient) CreateRouteTable(ctx context.Context, request ocicore.CreateRouteTableRequest) (response ocicore.CreateRouteTableResponse, err error) {
+
+	rt := ocicore.RouteTable{}
+	ocid := string(uuid.NewUUID())
+	rt.Id = &ocid
+	vcnc.routeTables[ocid] = rt
+
+	response = ocicore.CreateRouteTableResponse{}
+	response.RouteTable = rt
+	return response, nil
+}
+
+// UpdateRouteTable returns a fake response for UpdateRouteTable
+func (vcnc *VcnClient) UpdateRouteTable(ctx context.Context, request ocicore.UpdateRouteTableRequest) (response ocicore.UpdateRouteTableResponse, err error) {
+
+	if rt, ok := vcnc.routeTables[*request.RtId]; ok {
+		response = ocicore.UpdateRouteTableResponse{}
+		response.RouteTable = rt
+		return response, nil
+	}
+	response = ocicore.UpdateRouteTableResponse{}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+// DeleteRouteTable returns a fake response for DeleteRouteTable
+func (vcnc *VcnClient) DeleteRouteTable(ctx context.Context, request ocicore.DeleteRouteTableRequest) (response ocicore.DeleteRouteTableResponse, err error) {
+
+	id := *request.RtId
+	delete(vcnc.routeTables, id)
+	response = ocicore.DeleteRouteTableResponse{}
+	return response, nil
+}
+
+// GetRouteTable returns a fake response for GetRouteTable
+func (vcnc *VcnClient) GetRouteTable(ctx context.Context, request ocicore.GetRouteTableRequest) (response ocicore.GetRouteTableResponse, err error) {
+	response = ocicore.GetRouteTableResponse{}
+	if rt, ok := vcnc.routeTables[*request.RtId]; ok {
+		response.RouteTable = rt
+		return response, nil
+	}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+// CreateVcn returns a fake response for CreateVcn
+func (vcnc *VcnClient) CreateVcn(ctx context.Context, request ocicore.CreateVcnRequest) (response ocicore.CreateVcnResponse, err error) {
+
+	response = ocicore.CreateVcnResponse{}
+	vcn := ocicore.Vcn{}
+	ocid := string(uuid.NewUUID())
+	vcn.Id = &ocid
+	vcn.CidrBlock = request.CidrBlock
+	vcn.CompartmentId = request.CompartmentId
+	vcn.DisplayName = request.DisplayName
+	vcn.DnsLabel = request.DnsLabel
+	vcnc.vcns[ocid] = vcn
+
+	response.Vcn = vcn
+	return response, nil
+}
+
+// DeleteVcn returns a fake response for DeleteVcn
+func (vcnc *VcnClient) DeleteVcn(ctx context.Context, request ocicore.DeleteVcnRequest) (response ocicore.DeleteVcnResponse, err error) {
+
+	id := *request.VcnId
+	delete(vcnc.vcns, id)
+	response = ocicore.DeleteVcnResponse{}
+	return response, nil
+}
+
+// GetVcn returns a fake response for GetVcn
+func (vcnc *VcnClient) GetVcn(ctx context.Context, request ocicore.GetVcnRequest) (response ocicore.GetVcnResponse, err error) {
+	response = ocicore.GetVcnResponse{}
+	if vcn, ok := vcnc.vcns[*request.VcnId]; ok {
+		response.Vcn = vcn
+		return response, nil
+	}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+// UpdateVcn returns a fake response for UpdateVcn
+func (vcnc *VcnClient) UpdateVcn(ctx context.Context, request ocicore.UpdateVcnRequest) (response ocicore.UpdateVcnResponse, err error) {
+	if vcn, ok := vcnc.vcns[*request.VcnId]; ok {
+		response = ocicore.UpdateVcnResponse{}
+		response.Vcn = vcn
+		return response, nil
+	}
+	response = ocicore.UpdateVcnResponse{}
+	return response, servicefailure{Message: "Not found", Code: "NotAuthorizedOrNotFound"}
+}
+
+// GetVnic returns a fake response for GetVnic
+func (vcnc *VcnClient) GetVnic(ctx context.Context, request ocicore.GetVnicRequest) (response ocicore.GetVnicResponse, err error) {
+	response = ocicore.GetVnicResponse{}
+	isPrimary := true
+	vnic := ocicore.Vnic{
+		IsPrimary: &isPrimary,
+	}
+	response.Vnic = vnic
+	return response, nil
+}
+
+// ListInternetGateways returns a fake response for ListInternetGateways
+func (vcnc *VcnClient) ListInternetGateways(ctx context.Context, request ocicore.ListInternetGatewaysRequest) (response ocicore.ListInternetGatewaysResponse, err error) {
+	response = ocicore.ListInternetGatewaysResponse{}
+	response.Items = []ocicore.InternetGateway{}
+	for _, value := range vcnc.internetGateways {
+		response.Items = append(response.Items, value)
+	}
+
+	return response, nil
+}
+
+// ListNatGateways returns a fake response for ListNatGateways
+func (vcnc *VcnClient) ListNatGateways(ctx context.Context, request ocicore.ListNatGatewaysRequest) (response ocicore.ListNatGatewaysResponse, err error) {
+	response = ocicore.ListNatGatewaysResponse{}
+	response.Items = []ocicore.NatGateway{}
+	for _, value := range vcnc.natGateways {
+		response.Items = append(response.Items, value)
+	}
+
+	return response, nil
+}
+
+// TODO ListRouteTables returns a fake response for ListRouteTables
+func (vcnc *VcnClient) ListRouteTables(ctx context.Context, request ocicore.ListRouteTablesRequest) (response ocicore.ListRouteTablesResponse, err error) {
+	response = ocicore.ListRouteTablesResponse{}
+	response.Items = []ocicore.RouteTable{}
+	for _, value := range vcnc.routeTables {
+		response.Items = append(response.Items, value)
+	}
+
+	return response, nil
+}
+
+// TODO ListSecurityLists returns a fake response for ListSecurityLists
+func (vcnc *VcnClient) ListSecurityLists(ctx context.Context, request ocicore.ListSecurityListsRequest) (response ocicore.ListSecurityListsResponse, err error) {
+	response = ocicore.ListSecurityListsResponse{}
+	response.Items = []ocicore.SecurityList{}
+	for _, value := range vcnc.securityLists {
+		response.Items = append(response.Items, value)
+	}
+
+	return response, nil
+}
+
+func (vcnc *VcnClient) ListServiceGateways(ctx context.Context, request ocicore.ListServiceGatewaysRequest) (response ocicore.ListServiceGatewaysResponse, err error) {
+	response = ocicore.ListServiceGatewaysResponse{}
+	response.Items = []ocicore.ServiceGateway{}
+	for _, value := range vcnc.serviceGateways {
+		response.Items = append(response.Items, value)
+	}
+	return response, nil
+}
+
+func (vcnc *VcnClient) ListServices(ctx context.Context, request ocicore.ListServicesRequest) (response ocicore.ListServicesResponse, err error) {
+	serviceID := string(uuid.NewUUID())
+	serviceName := "All Services In Oracle Services Network"
+	cidrBlock := "oci-services"
+	description := "All Oracle Services Network services"
+	response = ocicore.ListServicesResponse{}
+	response.Items = []ocicore.Service{{
+		Id:          &serviceID,
+		Name:        &serviceName,
+		CidrBlock:   &cidrBlock,
+		Description: &description,
+	}}
+	return response, nil
+}
+
+// TODO ListSubnets returns a fake response for ListSubnets
+func (vcnc *VcnClient) ListSubnets(ctx context.Context, request ocicore.ListSubnetsRequest) (response ocicore.ListSubnetsResponse, err error) {
+	response = ocicore.ListSubnetsResponse{}
+	response.Items = []ocicore.Subnet{}
+	for _, value := range vcnc.subnets {
+		response.Items = append(response.Items, value)
+	}
+
+	return response, nil
+}
+
+// TODO ListVcns returns a fake response for ListVcns
+func (vcnc *VcnClient) ListVcns(ctx context.Context, request ocicore.ListVcnsRequest) (response ocicore.ListVcnsResponse, err error) {
+	response = ocicore.ListVcnsResponse{}
+	response.Items = []ocicore.Vcn{}
+	for _, value := range vcnc.vcns {
+		response.Items = append(response.Items, value)
+	}
+
+	return response, nil
+}

--- a/oke/oke_manager_client.go
+++ b/oke/oke_manager_client.go
@@ -60,10 +60,10 @@ const (
 // Defines / contains the OCI/OKE/Identity clients and operations.
 type ClusterManagerClient struct {
 	configuration         common.ConfigurationProvider
-	containerEngineClient containerengine.ContainerEngineClient
-	computeClient         core.ComputeClient
-	virtualNetworkClient  core.VirtualNetworkClient
-	identityClient        identity.IdentityClient
+	containerEngineClient ContainerEngineClientInterface
+	computeClient         ComputeClientInterface
+	virtualNetworkClient  VcnClientInterface
+	identityClient        IdentityClientInterface
 	sleepDuration         time.Duration
 	// TODO we could also include the retry settings here
 }
@@ -110,6 +110,12 @@ func NewClusterManagerClient(configuration common.ConfigurationProvider) (*Clust
 		sleepDuration:         5,
 	}
 	return c, nil
+}
+
+func (mgr *ClusterManagerClient) sleep(duration time.Duration) {
+	if mgr.sleepDuration > 0 {
+		time.Sleep(duration)
+	}
 }
 
 // CreateCluster creates a new cluster with no initial node pool and attaches
@@ -199,7 +205,7 @@ func (mgr *ClusterManagerClient) CreateCluster(ctx context.Context, state *State
 	// wait until cluster creation work request complete
 	logrus.Infof("[oraclecontainerengine] Waiting for cluster [%s] to reach Active status...", state.Name)
 	// initial delay since subsequent back-off function waits longer each time the retry fails
-	time.Sleep(time.Minute * 3)
+	mgr.sleep(time.Minute * 3)
 	workReqRespCluster, err := waitUntilContainerEngineWorkRequestComplete(mgr.containerEngineClient, clusterResp.OpcWorkRequestId)
 	if err != nil {
 		logrus.Errorf("[oraclecontainerengine] get work request for cluster creation failed with error %v", err)
@@ -385,7 +391,7 @@ func (mgr *ClusterManagerClient) CreateNodePools(ctx context.Context, state *Sta
 			// wait until cluster creation work request complete
 			logrus.Infof("[oraclecontainerengine] Waiting for node pool to be created for cluster [%s]...", state.Name)
 			// initial delay since subsequent back-off function waits longer each time the retry fails
-			time.Sleep(time.Minute * 5)
+			mgr.sleep(time.Minute * 5)
 			workReqRespNodePool, err := waitUntilContainerEngineWorkRequestComplete(mgr.containerEngineClient, createNodePoolResp.OpcWorkRequestId)
 			if err != nil {
 				logrus.Errorf("[oraclecontainerengine] get work request for node pool creation failed with error %v", err)
@@ -413,7 +419,7 @@ func (mgr *ClusterManagerClient) CreateNodePools(ctx context.Context, state *Sta
 							doneWaiting = true
 							break
 						}
-						time.Sleep(1 * time.Minute)
+						mgr.sleep(1 * time.Minute)
 					}
 					if doneWaiting {
 						break
@@ -503,7 +509,7 @@ func (mgr *ClusterManagerClient) createNodePoolPlacements(ctx context.Context, s
 
 }
 
-func (mgr *ClusterManagerClient) getImageID(ctx context.Context, c core.ComputeClient, compartment, shape, displayName string) (string, error) {
+func (mgr *ClusterManagerClient) getImageID(ctx context.Context, c ComputeClientInterface, compartment, shape, displayName string) (string, error) {
 	logrus.Tracef("[oraclecontainerengine] getImageID(...) called")
 	request := containerengine.GetNodePoolOptionsRequest{
 		CompartmentId:    common.String(compartment),
@@ -563,7 +569,7 @@ func (mgr *ClusterManagerClient) ScaleNodePool(ctx context.Context, nodePoolID s
 		logrus.Errorf("[oraclecontainerengine] scale node pool request failed with error %v", err)
 		return err
 	}
-	time.Sleep(time.Second * 30)
+	mgr.sleep(time.Second * 30)
 	logrus.Info("[oraclecontainerengine] Waiting for node pool update (scale) to complete...")
 	_, err = waitUntilContainerEngineWorkRequestComplete(mgr.containerEngineClient, resp.OpcWorkRequestId)
 	if err != nil {
@@ -647,7 +653,7 @@ func (mgr *ClusterManagerClient) UpdateNodepoolKubernetesVersion(ctx context.Con
 		logrus.Errorf("[oraclecontainerengine] upgrade Kubernetes version on node pool failed with error %v", err)
 		return err
 	}
-	time.Sleep(time.Second * 30)
+	mgr.sleep(time.Second * 30)
 	logrus.Info("[oraclecontainerengine] Waiting for node pool update (upgrade) to complete...")
 	_, err = waitUntilContainerEngineWorkRequestComplete(mgr.containerEngineClient, resp.OpcWorkRequestId)
 	if err != nil {
@@ -837,7 +843,7 @@ func (mgr *ClusterManagerClient) ReconcileNodePool(ctx context.Context, nodePool
 			logrus.Errorf("[oraclecontainerengine] OKE node pool reconciliation failed with error %v", err)
 			return err
 		}
-		time.Sleep(time.Second * 30)
+		mgr.sleep(time.Second * 30)
 		logrus.Info("[oraclecontainerengine] Waiting for node pool update (sync) to complete...")
 		_, err = waitUntilContainerEngineWorkRequestComplete(mgr.containerEngineClient, resp.OpcWorkRequestId)
 		if err != nil {
@@ -924,7 +930,7 @@ func (mgr *ClusterManagerClient) ReconcileCluster(ctx context.Context, clusterID
 				logrus.Errorf("[oraclecontainerengine] OKE cluster endpoint reconciliation failed with error %v", err)
 				return err
 			}
-			time.Sleep(3 * 60 * time.Second)
+			mgr.sleep(3 * 60 * time.Second)
 		}
 
 		resp, err := mgr.containerEngineClient.UpdateCluster(ctx, diffs)
@@ -932,7 +938,7 @@ func (mgr *ClusterManagerClient) ReconcileCluster(ctx context.Context, clusterID
 			logrus.Errorf("[oraclecontainerengine] OKE cluster reconciliation failed with error %v", err)
 			return err
 		}
-		time.Sleep(time.Second * 30)
+		mgr.sleep(time.Second * 30)
 		logrus.Info("[oraclecontainerengine] Waiting for cluster update (sync) to complete...")
 		_, err = waitUntilContainerEngineWorkRequestComplete(mgr.containerEngineClient, resp.OpcWorkRequestId)
 		if err != nil {
@@ -1282,7 +1288,7 @@ func (mgr *ClusterManagerClient) DeleteNodePool(ctx context.Context, nodePoolID 
 	// wait until node pool deletion work request complete
 	logrus.Infof("[oraclecontainerengine] Waiting for node pool to be deleted...")
 	// TODO better to poll instead of sleep
-	time.Sleep(mgr.sleepDuration * time.Second)
+	mgr.sleep(mgr.sleepDuration * time.Second)
 	_, err = waitUntilContainerEngineWorkRequestComplete(mgr.containerEngineClient, deleteNodePoolResp.OpcWorkRequestId)
 	if err != nil {
 		logrus.Errorf("[oraclecontainerengine] get work request for node pool deletion failed with error %v", err)
@@ -1314,7 +1320,7 @@ func (mgr *ClusterManagerClient) DeleteCluster(ctx context.Context, clusterID st
 	// wait until cluster deletion work request complete
 	logrus.Infof("[oraclecontainerengine] Waiting for cluster [%s] to be deleted...", clusterID)
 	// initial delay since subsequent back-off function waits longer each time the retry fails
-	time.Sleep(time.Minute * 3)
+	mgr.sleep(time.Minute * 3)
 	logrus.Info("[oraclecontainerengine] Waiting for cluster deletion to complete...")
 	_, err = waitUntilContainerEngineWorkRequestComplete(mgr.containerEngineClient, deleteClusterResp.OpcWorkRequestId)
 	if err != nil {
@@ -1411,7 +1417,7 @@ func (mgr *ClusterManagerClient) DeleteVCN(ctx context.Context, vcnID string, cl
 		}
 	}
 	// TODO better to poll instead of sleep
-	time.Sleep(mgr.sleepDuration * time.Second)
+	mgr.sleep(mgr.sleepDuration * time.Second)
 
 	// Delete all security lists from VCN
 	listSecurityListsReq := core.ListSecurityListsRequest{}
@@ -1560,7 +1566,7 @@ func (mgr *ClusterManagerClient) CreateNodeSubnets(ctx context.Context, state *S
 		logrus.Debugf("[oraclecontainerengine] creating private regional node subnet in VCN ID %s", vcnID)
 	}
 
-	var subnetIds = []string{}
+	var subnetIds []string
 	if state == nil {
 		logrus.Error("[oraclecontainerengine] valid state is required")
 		return subnetIds, fmt.Errorf("[oraclecontainerengine] valid state is required")
@@ -1663,7 +1669,7 @@ func (mgr *ClusterManagerClient) CreateBastionSubnets(ctx context.Context, state
 	logrus.Tracef("[oraclecontainerengine] CreateBastionSubnets(...) called")
 	logrus.Debugf("[oraclecontainerengine] creating bastion subnet(s) in VCN ID %s", vcnID)
 
-	var subnetIds = []string{}
+	var subnetIds []string
 	if state == nil {
 		return subnetIds, fmt.Errorf("[oraclecontainerengine] valid state is required")
 	}
@@ -1773,7 +1779,7 @@ func (mgr *ClusterManagerClient) CreateVCNAndNetworkResources(state *State) (str
 		return "", "", nil, nil, err
 	}
 	// TODO better to poll instead of sleep
-	time.Sleep(mgr.sleepDuration * time.Second)
+	mgr.sleep(mgr.sleepDuration * time.Second)
 
 	var trueVar = true
 	// Create an internet gateway
@@ -2234,7 +2240,7 @@ func getContainerEngineResourceID(resources []containerengine.WorkRequestResourc
 }
 
 // wait until container engine work request finish
-func waitUntilContainerEngineWorkRequestComplete(client containerengine.ContainerEngineClient, workRequestID *string) (containerengine.GetWorkRequestResponse, error) {
+func waitUntilContainerEngineWorkRequestComplete(client ContainerEngineClientInterface, workRequestID *string) (containerengine.GetWorkRequestResponse, error) {
 	// TODO - this function seems to be taking too long and not returning as
 	//  soon as the job appears to be complete.
 	logrus.Tracef("[oraclecontainerengine] waitUntilContainerEngineWorkRequestComplete(...) called")
@@ -2288,7 +2294,7 @@ func (mgr *ClusterManagerClient) numADs(ctx context.Context, compartmentID strin
 	return len(ads.Items)
 }
 
-func getDefaultKubernetesVersion(client containerengine.ContainerEngineClient) (*string, error) {
+func getDefaultKubernetesVersion(client ContainerEngineClientInterface) (*string, error) {
 	logrus.Tracef("[oraclecontainerengine] getDefaultKubernetesVersion(...) called")
 	getClusterOptionsReq := containerengine.GetClusterOptionsRequest{
 		ClusterOptionId: common.String("all"),

--- a/oke/oke_manager_client_test.go
+++ b/oke/oke_manager_client_test.go
@@ -1,0 +1,353 @@
+package oke
+
+import (
+	"github.com/rancher-plugins/kontainer-engine-driver-oke/oke/fakes"
+	"github.com/rancher/kontainer-engine/types"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	"testing"
+)
+
+var state State
+
+func init() {
+	info := types.ClusterInfo{}
+	state, _ = GetState(&info)
+	state.Name = "test-cluster"
+	state.Network.VCNName = "test-vcn"
+	state.CompartmentID = "ocid1.compartment.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	state.Network.VcnCompartmentID = "ocid1.compartment.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	state.Network.ControlPlaneSubnetName = controlPlaneSubnetName
+	state.Network.NodePoolSubnetName = nodeSubnetName
+	state.Network.NodePoolSubnetDnsDomainName = nodeSubnetName
+	state.Network.NodePoolSubnetSecurityListName = nodePoolSubnetSecurityListName
+	state.Network.ServiceSubnetDnsDomainName = serviceSubnetName
+	state.Network.ServiceSubnetSecurityListName = serviceSubnetSecurityListName
+	state.NodePool.NodeImageName = "Oracle-Linux-7.7"
+	state.NodePool.NodeShape = "VM.Standard2.1"
+	state.NodePool.QuantityPerSubnet = 1
+}
+
+func TestCreateSubnets(t *testing.T) {
+
+	oke, err := constructFakeClusterManagerClient()
+	assert.Nil(t, err)
+	assert.NotNil(t, oke)
+
+	publicSubnet, err := oke.CreateSubnetWithDetails(nil, nil, nil, nil, nil, nil, false, nil, &state)
+	assert.Nil(t, err)
+	assert.NotNil(t, publicSubnet)
+	assert.False(t, *publicSubnet.ProhibitPublicIpOnVnic)
+
+	privateSubnet, err := oke.CreateSubnetWithDetails(nil, nil, nil, nil, nil, nil, true, nil, &state)
+	assert.Nil(t, err)
+	assert.NotNil(t, privateSubnet)
+	assert.True(t, *privateSubnet.ProhibitPublicIpOnVnic)
+}
+
+func TestVCNCRUD(t *testing.T) {
+	oke, err := constructFakeClusterManagerClient()
+	assert.Nil(t, err)
+	assert.NotNil(t, oke)
+
+	vcnID, _, serviceSubnetIDs, nodeSubnetIds, err := oke.CreateVCNAndNetworkResources(&state)
+	assert.Nil(t, err)
+	assert.NotNil(t, vcnID)
+	assert.True(t, len(nodeSubnetIds) == 1)
+	assert.True(t, len(serviceSubnetIDs) == 1)
+
+	// Spot check looking up VCN and subnets by name
+
+	vcnID, err = oke.GetVcnIDByName(context.Background(), state.Network.VcnCompartmentID, state.Network.VCNName)
+	assert.Nil(t, err)
+	assert.NotNil(t, vcnID)
+
+	subnetIDN1, err := oke.GetSubnetIDByName(context.Background(), state.Network.VcnCompartmentID, vcnID, state.Network.NodePoolSubnetName)
+	assert.Nil(t, err)
+	assert.True(t, len(subnetIDN1) > 0)
+
+	subnetIDS2, err := oke.GetSubnetByName(context.Background(), state.Network.VcnCompartmentID, vcnID, state.Network.ServiceSubnetDnsDomainName)
+	assert.Nil(t, err)
+	assert.NotNil(t, subnetIDS2.Id)
+	assert.True(t, len(*subnetIDS2.Id) > 0)
+
+	_, err = oke.GetVcnIDByName(context.Background(), state.Network.VcnCompartmentID, "DNE")
+	assert.NotNil(t, err)
+
+	_, err = oke.GetSubnetIDByName(context.Background(), state.Network.VcnCompartmentID, vcnID, "DNE")
+	assert.NotNil(t, err)
+
+	// There should be 3 subnets (control-plane, node, and service)
+	subnetIds, err := oke.ListSubnetIdsInVcn(context.Background(), state.CompartmentID, vcnID)
+	assert.Nil(t, err)
+	assert.True(t, len(subnetIds) == 3)
+
+	// There should be 1 IG and at least 2 security lists
+	routeTableIds, err := oke.ListRouteTableIdsInVcn(context.Background(), state.CompartmentID, vcnID)
+	assert.Nil(t, err)
+	assert.True(t, len(routeTableIds) == 1)
+
+	internetGatewayIds, err := oke.ListInternetGatewayIdsInVcn(context.Background(), state.CompartmentID, vcnID)
+	assert.Nil(t, err)
+	assert.True(t, len(internetGatewayIds) >= 1)
+
+	securityListIds, err := oke.ListSecurityListIdsInVcn(context.Background(), state.CompartmentID, vcnID)
+	assert.Nil(t, err)
+	assert.True(t, len(securityListIds) >= 2)
+
+	err = oke.DeleteVCN(context.Background(), vcnID, state.ClusterID)
+	assert.Nil(t, err)
+
+	// There should be no more resources under this subnet
+	subnetIds, err = oke.ListSubnetIdsInVcn(context.Background(), state.CompartmentID, vcnID)
+	assert.Nil(t, err)
+	assert.True(t, len(subnetIds) == 0)
+	internetGatewayIds, err = oke.ListInternetGatewayIdsInVcn(context.Background(), state.CompartmentID, vcnID)
+	assert.Nil(t, err)
+	assert.True(t, len(internetGatewayIds) == 0)
+
+	// Looking up a deleted subnet should result in an error
+	vcnID, err = oke.GetVcnIDByName(context.Background(), state.Network.VcnCompartmentID, state.Network.VCNName)
+	assert.NotNil(t, err)
+}
+
+func TestClusterCRUD(t *testing.T) {
+	oke, err := constructFakeClusterManagerClient()
+	assert.Nil(t, err)
+	assert.NotNil(t, oke)
+
+	defaultKubernetesVersion, err := getDefaultKubernetesVersion(oke.containerEngineClient)
+	assert.Nil(t, err)
+	assert.True(t, *defaultKubernetesVersion != "")
+
+	vcnID, controlPlaneSubnetID, serviceSubnetIDs, nodeSubnetIds, err := oke.CreateVCNAndNetworkResources(&state)
+	assert.Nil(t, err)
+	assert.NotNil(t, vcnID)
+	assert.True(t, len(nodeSubnetIds) > 0)
+	assert.True(t, len(serviceSubnetIDs) > 0)
+
+	err = oke.CreateCluster(context.Background(), &state, vcnID, controlPlaneSubnetID, serviceSubnetIDs, nodeSubnetIds)
+	assert.Nil(t, err)
+	assert.NotNil(t, state.ClusterID)
+
+	cluster, err := oke.GetClusterByID(context.Background(), state.ClusterID)
+	assert.Nil(t, err)
+	assert.NotNil(t, cluster)
+	assert.NotNil(t, *cluster.Id)
+	assert.NotNil(t, *cluster.Name)
+	assert.NotNil(t, *cluster.VcnId)
+	assert.True(t, *cluster.KubernetesVersion == *defaultKubernetesVersion)
+	assert.True(t, len(cluster.Options.ServiceLbSubnetIds) == 1)
+	assert.True(t, len(*cluster.VcnId) > 0)
+
+	err = oke.UpdateMasterKubernetesVersion(context.Background(), state.ClusterID, "v1.19.9")
+	assert.Nil(t, err)
+	cluster, err = oke.GetClusterByID(context.Background(), state.ClusterID)
+	assert.Nil(t, err)
+	assert.True(t, *cluster.KubernetesVersion == "v1.19.9")
+
+	vcnID1, err := oke.GetVcnIDByClusterID(context.Background(), *cluster.Id)
+	assert.Nil(t, err)
+	assert.True(t, vcnID1 != "")
+	assert.True(t, len(vcnID1) > 0)
+	assert.Equal(t, vcnID1, vcnID)
+
+	err = oke.DeleteCluster(context.Background(), *cluster.Id)
+	assert.Nil(t, err)
+
+	// Looking up a deleted cluster should result in an error
+	cluster, err = oke.GetClusterByID(context.Background(), state.ClusterID)
+	assert.NotNil(t, err)
+	assert.Nil(t, cluster.Id)
+}
+
+func TestClusterCRUDWithNodePool(t *testing.T) {
+	oke, err := constructFakeClusterManagerClient()
+	assert.Nil(t, err)
+	assert.NotNil(t, oke)
+
+	defaultKubernetesVersion, err := getDefaultKubernetesVersion(oke.containerEngineClient)
+	assert.Nil(t, err)
+	assert.True(t, *defaultKubernetesVersion != "")
+
+	vcnID, controlPlaneSubnetID, serviceSubnetIDs, nodeSubnetIds, err := oke.CreateVCNAndNetworkResources(&state)
+	assert.Nil(t, err)
+	assert.NotNil(t, vcnID)
+	assert.True(t, len(nodeSubnetIds) > 0)
+	assert.True(t, len(serviceSubnetIDs) > 0)
+
+	err = oke.CreateCluster(context.Background(), &state, vcnID, controlPlaneSubnetID, serviceSubnetIDs, nodeSubnetIds)
+	assert.Nil(t, err)
+	assert.NotNil(t, state.ClusterID)
+
+	clusterId, err := oke.GetClusterByName(context.Background(), state.CompartmentID, state.Name)
+	assert.Nil(t, err)
+	assert.NotNil(t, clusterId)
+
+	_, err = oke.GetClusterByName(context.Background(), state.CompartmentID, "DNE")
+	assert.NotNil(t, err)
+
+	err = oke.CreateNodePools(context.Background(), &state, vcnID, serviceSubnetIDs, nodeSubnetIds)
+	assert.Nil(t, err)
+
+	nodePoolIDs, err := oke.ListNodepoolIdsInCluster(context.Background(), state.CompartmentID, state.ClusterID)
+	assert.Nil(t, err)
+	assert.True(t, len(nodePoolIDs) == 1)
+
+	nodePool, err := oke.GetNodePoolByID(context.Background(), nodePoolIDs[0])
+
+	assert.Nil(t, err)
+	assert.NotNil(t, nodePool)
+	assert.NotNil(t, *nodePool.Id)
+	assert.NotNil(t, *nodePool.Name)
+	assert.NotNil(t, *nodePool.ClusterId)
+	assert.Equal(t, *nodePool.Id, nodePoolIDs[0])
+	assert.Equal(t, *nodePool.ClusterId, clusterId)
+	assert.True(t, int64(*nodePool.QuantityPerSubnet) == state.NodePool.QuantityPerSubnet)
+	assert.True(t, *nodePool.KubernetesVersion == *defaultKubernetesVersion)
+
+	err = oke.ScaleNodePool(context.Background(), nodePoolIDs[0], int(state.NodePool.QuantityPerSubnet)+1, state.CompartmentID)
+	assert.Nil(t, err)
+	nodePool, _ = oke.GetNodePoolByID(context.Background(), nodePoolIDs[0])
+	assert.Equal(t, *nodePool.Id, nodePoolIDs[0])
+	assert.True(t, int64(*nodePool.QuantityPerSubnet) == state.NodePool.QuantityPerSubnet+1)
+
+	err = oke.UpdateNodepoolKubernetesVersion(context.Background(), *nodePool.Id, "v1.19.9")
+	assert.Nil(t, err)
+	nodePool, _ = oke.GetNodePoolByID(context.Background(), nodePoolIDs[0])
+	assert.Equal(t, *nodePool.Id, nodePoolIDs[0])
+	assert.Nil(t, err)
+	assert.True(t, *nodePool.KubernetesVersion == "v1.19.9")
+	assert.True(t, int64(*nodePool.QuantityPerSubnet) == state.NodePool.QuantityPerSubnet+1)
+
+	err = oke.DeleteNodePool(context.Background(), nodePoolIDs[0])
+	assert.Nil(t, err)
+	nodePoolIDs, err = oke.ListNodepoolIdsInCluster(context.Background(), state.CompartmentID, state.ClusterID)
+	assert.Nil(t, err)
+	assert.True(t, len(nodePoolIDs) == 0)
+
+	err = oke.DeleteCluster(context.Background(), state.ClusterID)
+	assert.Nil(t, err)
+
+	// Looking up a deleted node pool should result in an error
+	clusterId, err = oke.GetClusterByName(context.Background(), state.CompartmentID, state.Name)
+	assert.NotNil(t, err)
+	assert.True(t, clusterId == "")
+}
+
+func TestPrivateCluster(t *testing.T) {
+
+	state.PrivateNodes = true
+
+	oke, err := constructFakeClusterManagerClient()
+	assert.Nil(t, err)
+	assert.NotNil(t, oke)
+
+	vcnID, controlPlaneSubnetID, serviceSubnetIDs, nodeSubnetIds, err := oke.CreateVCNAndNetworkResources(&state)
+	assert.Nil(t, err)
+	assert.NotNil(t, vcnID)
+	assert.True(t, len(nodeSubnetIds) > 0)
+	assert.True(t, len(serviceSubnetIDs) > 0)
+
+	// There should be 3 subnets (control-plane, node, and service)
+	subnetIds, err := oke.ListSubnetIdsInVcn(context.Background(), state.CompartmentID, vcnID)
+	assert.Nil(t, err)
+	assert.True(t, len(subnetIds) == 3)
+
+	// A NAT Gateway should have been created when private nodes are enabled
+	natGatewayIds, err := oke.ListNatGatewayIdsInVcn(context.Background(), state.CompartmentID, vcnID)
+	assert.Nil(t, err)
+	assert.True(t, len(natGatewayIds) == 1)
+
+	// And at least two route tables - one for the internet gateway and one for the NAT gateway
+	routeTableIds, err := oke.ListRouteTableIdsInVcn(context.Background(), state.CompartmentID, vcnID)
+	assert.Nil(t, err)
+	assert.True(t, len(routeTableIds) >= 2)
+
+	subnetNode1, err := oke.GetSubnetByName(context.Background(), state.Network.VcnCompartmentID, vcnID, state.Network.NodePoolSubnetName)
+	assert.Nil(t, err)
+	assert.NotNil(t, subnetNode1.RouteTableId)
+	// Node has an explicit route for private workers.
+	assert.True(t, len(*subnetNode1.RouteTableId) > 0)
+
+	subnetService1, err := oke.GetSubnetByName(context.Background(), state.Network.VcnCompartmentID, vcnID, state.Network.ServiceSubnetDnsDomainName)
+	assert.Nil(t, err)
+	// Default route can be null for service subnet or be the IG route, but always different than the node's NAT route.
+	if subnetService1.RouteTableId != nil {
+		assert.NotEqual(t, *subnetService1.RouteTableId, *subnetNode1.RouteTableId)
+	}
+
+	err = oke.CreateCluster(context.Background(), &state, vcnID, controlPlaneSubnetID, serviceSubnetIDs, nodeSubnetIds)
+	assert.Nil(t, err)
+	assert.NotNil(t, state.ClusterID)
+
+	err = oke.CreateNodePools(context.Background(), &state, vcnID, serviceSubnetIDs, nodeSubnetIds)
+	assert.Nil(t, err)
+
+	nodePoolIDs, err := oke.ListNodepoolIdsInCluster(context.Background(), state.CompartmentID, state.ClusterID)
+	assert.Nil(t, err)
+	assert.True(t, len(nodePoolIDs) == 1)
+
+	nodePool, err := oke.GetNodePoolByID(context.Background(), nodePoolIDs[0])
+
+	assert.Nil(t, err)
+	assert.NotNil(t, nodePool)
+	assert.NotNil(t, *nodePool.Id)
+	assert.NotNil(t, *nodePool.Name)
+	assert.NotNil(t, *nodePool.ClusterId)
+	assert.Equal(t, *nodePool.Id, nodePoolIDs[0])
+	assert.True(t, int64(*nodePool.QuantityPerSubnet) == state.NodePool.QuantityPerSubnet)
+
+	err = oke.DeleteNodePool(context.Background(), nodePoolIDs[0])
+	assert.Nil(t, err)
+	nodePoolIDs, err = oke.ListNodepoolIdsInCluster(context.Background(), state.CompartmentID, state.ClusterID)
+	assert.Nil(t, err)
+	assert.True(t, len(nodePoolIDs) == 0)
+}
+
+// newFakeClusterManagerClient creates a new OCI cluster manager, which has fake clients CE, VCN, Identity clients.
+func newFakeClusterManagerClient() (*ClusterManagerClient, error) {
+
+	containerClient, err := fakes.NewContainerEngineClient()
+	if err != nil {
+		logrus.Debugf("create new (fake) ContainerEngine client failed with err %v", err)
+		return nil, err
+	}
+	vNetClient, err := fakes.NewVcnClient()
+	if err != nil {
+		logrus.Debugf("create new (fake) VirtualNetwork client failed with err %v", err)
+		return nil, err
+	}
+	identityClient, err := fakes.NewIdentityClient()
+	if err != nil {
+		logrus.Debugf("create new (fake) Identity client failed with err %v", err)
+		return nil, err
+	}
+	computeClient, err := fakes.NewComputeClient()
+	if err != nil {
+		logrus.Debugf("create new (fake) Compute client failed with err %v", err)
+		return nil, err
+	}
+
+	c := &ClusterManagerClient{
+		containerEngineClient: containerClient,
+		computeClient:         computeClient,
+		virtualNetworkClient:  vNetClient,
+		identityClient:        identityClient,
+		sleepDuration:         0,
+	}
+
+	return c, nil
+}
+
+// constructFakeClusterManagerClient is a helper function that constructs a new fake ClusterManagerClient.
+func constructFakeClusterManagerClient() (ClusterManagerClient, error) {
+
+	clusterMgrClient, err := newFakeClusterManagerClient()
+	if err != nil {
+		return ClusterManagerClient{}, err
+	}
+
+	return *clusterMgrClient, nil
+}

--- a/oke/types.go
+++ b/oke/types.go
@@ -1,0 +1,101 @@
+// Copyright 2019 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oke
+
+import (
+	"context"
+
+	ocice "github.com/oracle/oci-go-sdk/v65/containerengine"
+	ocicore "github.com/oracle/oci-go-sdk/v65/core"
+	ociid "github.com/oracle/oci-go-sdk/v65/identity"
+)
+
+// ContainerEngineClientInterface defines an interface for the oci ContainerEngine client to be implemented by real and fake clients
+type ContainerEngineClientInterface interface {
+	CreateCluster(ctx context.Context, request ocice.CreateClusterRequest) (response ocice.CreateClusterResponse, err error)
+	CreateKubeconfig(ctx context.Context, request ocice.CreateKubeconfigRequest) (response ocice.CreateKubeconfigResponse, err error)
+	CreateNodePool(ctx context.Context, request ocice.CreateNodePoolRequest) (response ocice.CreateNodePoolResponse, err error)
+	DeleteCluster(ctx context.Context, request ocice.DeleteClusterRequest) (response ocice.DeleteClusterResponse, err error)
+	DeleteNodePool(ctx context.Context, request ocice.DeleteNodePoolRequest) (response ocice.DeleteNodePoolResponse, err error)
+	GetCluster(ctx context.Context, request ocice.GetClusterRequest) (response ocice.GetClusterResponse, err error)
+	GetClusterOptions(ctx context.Context, request ocice.GetClusterOptionsRequest) (response ocice.GetClusterOptionsResponse, err error)
+	GetNodePool(ctx context.Context, request ocice.GetNodePoolRequest) (response ocice.GetNodePoolResponse, err error)
+	GetNodePoolOptions(ctx context.Context, request ocice.GetNodePoolOptionsRequest) (response ocice.GetNodePoolOptionsResponse, err error)
+	GetWorkRequest(ctx context.Context, request ocice.GetWorkRequestRequest) (response ocice.GetWorkRequestResponse, err error)
+	ListClusters(ctx context.Context, request ocice.ListClustersRequest) (response ocice.ListClustersResponse, err error)
+	ListNodePools(ctx context.Context, request ocice.ListNodePoolsRequest) (response ocice.ListNodePoolsResponse, err error)
+	UpdateCluster(ctx context.Context, request ocice.UpdateClusterRequest) (response ocice.UpdateClusterResponse, err error)
+	UpdateClusterEndpointConfig(ctx context.Context, request ocice.UpdateClusterEndpointConfigRequest) (response ocice.UpdateClusterEndpointConfigResponse, err error)
+	UpdateNodePool(ctx context.Context, request ocice.UpdateNodePoolRequest) (response ocice.UpdateNodePoolResponse, err error)
+}
+
+type ComputeClientInterface interface {
+	ListShapes(ctx context.Context, request ocicore.ListShapesRequest) (response ocicore.ListShapesResponse, err error)
+}
+
+// IdentityClientInterface defines an interface for the oci identity client to be implemented by real and fake clients
+type IdentityClientInterface interface {
+	GetCompartment(ctx context.Context, request ociid.GetCompartmentRequest) (response ociid.GetCompartmentResponse, err error)
+	CreateCompartment(ctx context.Context, request ociid.CreateCompartmentRequest) (response ociid.CreateCompartmentResponse, err error)
+	CreatePolicy(ctx context.Context, request ociid.CreatePolicyRequest) (response ociid.CreatePolicyResponse, err error)
+	DeleteCompartment(ctx context.Context, request ociid.DeleteCompartmentRequest) (response ociid.DeleteCompartmentResponse, err error)
+	DeletePolicy(ctx context.Context, request ociid.DeletePolicyRequest) (response ociid.DeletePolicyResponse, err error)
+	GetPolicy(ctx context.Context, request ociid.GetPolicyRequest) (response ociid.GetPolicyResponse, err error)
+	ListAvailabilityDomains(ctx context.Context, request ociid.ListAvailabilityDomainsRequest) (response ociid.ListAvailabilityDomainsResponse, err error)
+	ListCompartments(ctx context.Context, request ociid.ListCompartmentsRequest) (response ociid.ListCompartmentsResponse, err error)
+	ListFaultDomains(ctx context.Context, request ociid.ListFaultDomainsRequest) (response ociid.ListFaultDomainsResponse, err error)
+	UpdatePolicy(ctx context.Context, request ociid.UpdatePolicyRequest) (response ociid.UpdatePolicyResponse, err error)
+}
+
+// VcnClientInterface defines an interface for the oci vcn client to be implemented by real and fake clients
+type VcnClientInterface interface {
+	CreateDhcpOptions(ctx context.Context, request ocicore.CreateDhcpOptionsRequest) (response ocicore.CreateDhcpOptionsResponse, err error)
+	CreateInternetGateway(ctx context.Context, request ocicore.CreateInternetGatewayRequest) (response ocicore.CreateInternetGatewayResponse, err error)
+	CreateNatGateway(ctx context.Context, request ocicore.CreateNatGatewayRequest) (response ocicore.CreateNatGatewayResponse, err error)
+	CreateRouteTable(ctx context.Context, request ocicore.CreateRouteTableRequest) (response ocicore.CreateRouteTableResponse, err error)
+	CreateSecurityList(ctx context.Context, request ocicore.CreateSecurityListRequest) (response ocicore.CreateSecurityListResponse, err error)
+	CreateServiceGateway(ctx context.Context, request ocicore.CreateServiceGatewayRequest) (response ocicore.CreateServiceGatewayResponse, err error)
+	CreateSubnet(ctx context.Context, request ocicore.CreateSubnetRequest) (response ocicore.CreateSubnetResponse, err error)
+	CreateVcn(ctx context.Context, request ocicore.CreateVcnRequest) (response ocicore.CreateVcnResponse, err error)
+	DeleteDhcpOptions(ctx context.Context, request ocicore.DeleteDhcpOptionsRequest) (response ocicore.DeleteDhcpOptionsResponse, err error)
+	DeleteInternetGateway(ctx context.Context, request ocicore.DeleteInternetGatewayRequest) (response ocicore.DeleteInternetGatewayResponse, err error)
+	DeleteNatGateway(ctx context.Context, request ocicore.DeleteNatGatewayRequest) (response ocicore.DeleteNatGatewayResponse, err error)
+	DeleteRouteTable(ctx context.Context, request ocicore.DeleteRouteTableRequest) (response ocicore.DeleteRouteTableResponse, err error)
+	DeleteSecurityList(ctx context.Context, request ocicore.DeleteSecurityListRequest) (response ocicore.DeleteSecurityListResponse, err error)
+	DeleteServiceGateway(ctx context.Context, request ocicore.DeleteServiceGatewayRequest) (response ocicore.DeleteServiceGatewayResponse, err error)
+	DeleteSubnet(ctx context.Context, request ocicore.DeleteSubnetRequest) (response ocicore.DeleteSubnetResponse, err error)
+	DeleteVcn(ctx context.Context, request ocicore.DeleteVcnRequest) (response ocicore.DeleteVcnResponse, err error)
+	GetDhcpOptions(ctx context.Context, request ocicore.GetDhcpOptionsRequest) (response ocicore.GetDhcpOptionsResponse, err error)
+	GetInternetGateway(ctx context.Context, request ocicore.GetInternetGatewayRequest) (response ocicore.GetInternetGatewayResponse, err error)
+	GetRouteTable(ctx context.Context, request ocicore.GetRouteTableRequest) (response ocicore.GetRouteTableResponse, err error)
+	GetSecurityList(ctx context.Context, request ocicore.GetSecurityListRequest) (response ocicore.GetSecurityListResponse, err error)
+	GetSubnet(ctx context.Context, request ocicore.GetSubnetRequest) (response ocicore.GetSubnetResponse, err error)
+	GetVcn(ctx context.Context, request ocicore.GetVcnRequest) (response ocicore.GetVcnResponse, err error)
+	GetVnic(ctx context.Context, request ocicore.GetVnicRequest) (response ocicore.GetVnicResponse, err error)
+	ListInternetGateways(ctx context.Context, request ocicore.ListInternetGatewaysRequest) (response ocicore.ListInternetGatewaysResponse, err error)
+	ListNatGateways(ctx context.Context, request ocicore.ListNatGatewaysRequest) (response ocicore.ListNatGatewaysResponse, err error)
+	ListRouteTables(ctx context.Context, request ocicore.ListRouteTablesRequest) (response ocicore.ListRouteTablesResponse, err error)
+	ListSecurityLists(ctx context.Context, request ocicore.ListSecurityListsRequest) (response ocicore.ListSecurityListsResponse, err error)
+	ListServiceGateways(ctx context.Context, request ocicore.ListServiceGatewaysRequest) (response ocicore.ListServiceGatewaysResponse, err error)
+	ListServices(ctx context.Context, request ocicore.ListServicesRequest) (response ocicore.ListServicesResponse, err error)
+	ListSubnets(ctx context.Context, request ocicore.ListSubnetsRequest) (response ocicore.ListSubnetsResponse, err error)
+	ListVcns(ctx context.Context, request ocicore.ListVcnsRequest) (response ocicore.ListVcnsResponse, err error)
+	UpdateDhcpOptions(ctx context.Context, request ocicore.UpdateDhcpOptionsRequest) (response ocicore.UpdateDhcpOptionsResponse, err error)
+	UpdateInternetGateway(ctx context.Context, request ocicore.UpdateInternetGatewayRequest) (response ocicore.UpdateInternetGatewayResponse, err error)
+	UpdateRouteTable(ctx context.Context, request ocicore.UpdateRouteTableRequest) (response ocicore.UpdateRouteTableResponse, err error)
+	UpdateSecurityList(ctx context.Context, request ocicore.UpdateSecurityListRequest) (response ocicore.UpdateSecurityListResponse, err error)
+	UpdateSubnet(ctx context.Context, request ocicore.UpdateSubnetRequest) (response ocicore.UpdateSubnetResponse, err error)
+	UpdateVcn(ctx context.Context, request ocicore.UpdateVcnRequest) (response ocicore.UpdateVcnResponse, err error)
+}


### PR DESCRIPTION
This PR add some basic tests that exercise OKE driver CRUD (VCN, clusters, nodepools) using _fake_ OCI clients, which are intended to mimic the behavior of the _real_ clients.

The next step will hopefully be to set them up to run automatically. Eventually, it'd be nice to have a set of tests that run against the real OCI.