### PR TITLE
Modify create node image references

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/gogo/protobuf v1.3.0 // indirect
-	github.com/oracle/oci-go-sdk v13.0.0+incompatible
+	github.com/oracle/oci-go-sdk v19.0.0+incompatible
 	github.com/pkg/errors v0.8.1
 	github.com/rancher/kontainer-engine v0.0.0-20190711161432-b98bad2201bb
 	github.com/rancher/rke v0.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/oracle/oci-go-sdk v7.1.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukw
 github.com/oracle/oci-go-sdk v13.0.0+incompatible h1:ueAty9OrRXfWi+4gyPLKcOpzhf1OSK70mwt36sD/hf8=
 github.com/oracle/oci-go-sdk v13.0.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
 github.com/oracle/oci-go-sdk v13.1.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
+github.com/oracle/oci-go-sdk v19.0.0+incompatible h1:UQnOTZBLEtrqNnJ7jQJiaadScBQ7+CF61+OIvWktkoc=
+github.com/oracle/oci-go-sdk v19.0.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
 github.com/oracle/oci-manager v0.0.0-20181210225140-b3f0fa436c6b h1:6HTjRyMR6s3eUEYvrM1nvQ3gIT0RcWOqMoBhzRuzZRM=
 github.com/oracle/oci-manager v0.0.0-20181210225140-b3f0fa436c6b/go.mod h1:mu49MZKiWx61E+enfYwa8SO2eAcdumsr+eLbXCKfxbs=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=

--- a/oke/oke_manager_client.go
+++ b/oke/oke_manager_client.go
@@ -234,10 +234,10 @@ func (mgr *ClusterManagerClient) CreateNodePool(ctx context.Context, state *Stat
 	// get Image Id
 	image, err := getImageID(ctx, mgr.computeClient, state.CompartmentID, state.NodePool.NodeShape, state.NodePool.NodeImageName)
 	if err != nil {
-		fmt.Printf("Node ID not found")
+		logrus.Printf("Node ID not found")
 		npReq.NodeImageName = common.String(state.NodePool.NodeImageName)
 	} else {
-		fmt.Printf("Node ID found %v", image.Id)
+		logrus.Printf("Node ID found %v", image.Id)
 		npReq.NodeSourceDetails = containerengine.NodeSourceViaImageDetails{ImageId: image.Id}
 	}
 	npReq.Name = common.String(state.Name + "-1")


### PR DESCRIPTION
This merge request allows for a broader choice of node pool image shapes.

This is done by using oci image id when available and then using image display name as a fallback.

This works for all of the following cases:
    "Oracle-Linux-7.7-2020.03.23-0",
    "Oracle-Linux-7.7-2020.02.21-0",
    "Oracle-Linux-7.6"