### PR TITLE
Support kms key id for encrypting cluster secrets.

### DIFF
--- a/oke/oke_manager_client.go
+++ b/oke/oke_manager_client.go
@@ -134,6 +134,11 @@ func (mgr *ClusterManagerClient) CreateCluster(ctx context.Context, state *State
 	cReq.Name = common.String(state.Name)
 	cReq.CompartmentId = &state.CompartmentID
 	cReq.VcnId = common.String(vcnID)
+
+	if state.KmsKeyID != ""{
+		cReq.KmsKeyId = &state.KmsKeyID
+	}
+
 	cReq.KubernetesVersion = common.String(state.KubernetesVersion)
 	cReq.Options = &containerengine.ClusterCreateOptions{
 		ServiceLbSubnetIds: serviceSubnetIds,
@@ -186,6 +191,7 @@ func (mgr *ClusterManagerClient) CreateCluster(ctx context.Context, state *State
 
 	return nil
 }
+
 
 // GetClusterByID returns the cluster with the specified Id, or an error
 func (mgr *ClusterManagerClient) GetClusterByID(ctx context.Context, clusterID string) (containerengine.Cluster, error) {


### PR DESCRIPTION
Adds support for creating an OKE cluster where the Kubernetes secrets are encrypted at rest in etcd using the privide kms vault master key.

<img width="801" alt="Screen Shot 2021-06-09 at 6 44 56 PM" src="https://user-images.githubusercontent.com/30269407/121595509-34806e00-c9f3-11eb-8e02-99f01ccf1092.png">
