### PR TITLE
Move away from deprecated ioutil functions and creating temp files.

### DIFF
--- a/oke/oke_manager_client.go
+++ b/oke/oke_manager_client.go
@@ -22,7 +22,7 @@ and VCN.
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -1081,7 +1081,7 @@ func (mgr *ClusterManagerClient) GetKubeconfigByClusterID(ctx context.Context, c
 		return store.KubeConfig{}, "", err
 	}
 
-	content, err := ioutil.ReadAll(response.Content)
+	content, err := io.ReadAll(response.Content)
 	if err != nil {
 		logrus.Debugf("[oraclecontainerengine] error reading kubeconfig response content %v", err)
 		return store.KubeConfig{}, "", err


### PR DESCRIPTION
Resolves issue #70 by no longer attempting to create a temporary `kubeconfig` file on disk, which later Rancher releases do not support. 