### PR TITLE
Support instance principals (workload identity) for authentication.

### DIFF
--- a/oke/oke_manager_client.go
+++ b/oke/oke_manager_client.go
@@ -415,6 +415,7 @@ func (mgr *ClusterManagerClient) CreateNodePool(ctx context.Context, state *Stat
 func (mgr *ClusterManagerClient) getImageID(ctx context.Context, c core.ComputeClient, compartment, shape, displayName string) (string, error) {
 	logrus.Tracef("[oraclecontainerengine] getImageID(...) called")
 	request := containerengine.GetNodePoolOptionsRequest{
+		CompartmentId:    common.String(compartment),
 		NodePoolOptionId: common.String("all"),
 	}
 


### PR DESCRIPTION
Add support for different authentication mechanisms besides key based including instance principals and workload identity. 

For backwards compatibility, if username is specified to the driver, we continue to use key based. If username is not specified to the driver, we first try to authenticate using instance principals, then workload identity.